### PR TITLE
feature/28

### DIFF
--- a/lib/src/modules/authentication/authentication_module.dart
+++ b/lib/src/modules/authentication/authentication_module.dart
@@ -1,9 +1,0 @@
-import 'package:flutter_modular/flutter_modular.dart';
-
-class AuthenticationModule extends Module {
-  @override
-  List<Bind> get binds => [];
-
-  @override
-  List<ModularRoute> get routes => [];
-}

--- a/lib/src/modules/login/create_account/create_account_page.dart
+++ b/lib/src/modules/login/create_account/create_account_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:raro_budget/src/modules/login/create_account/widgets/name_email_widget.dart';
+import 'package:raro_budget/src/modules/login/create_account/widgets/password_widget.dart';
 import 'package:raro_budget/src/modules/login/create_account/widgets/phone_cpf_widget.dart';
 import 'package:raro_budget/src/modules/login/create_account/create_account_controller.dart';
 import 'package:raro_budget/src/modules/login/create_account/widgets/terms_widget.dart';
@@ -42,6 +43,7 @@ class _CreateAccountPageState extends State<CreateAccountPage> {
                 NameEmailWidget(),
                 PhoneCPFWidget(),
                 TermsWidget(),
+                PasswordWidget()
               ],
             ),
           ),

--- a/lib/src/modules/login/create_account/widgets/password_widget.dart
+++ b/lib/src/modules/login/create_account/widgets/password_widget.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:raro_budget/src/shared/constants/app_text_styles.dart';
+import 'package:raro_budget/src/shared/validators/validators.dart';
+import 'package:raro_budget/src/shared/widgets/custom_main_text_title/custom_main_text_title_widget.dart';
+import 'package:raro_budget/src/shared/widgets/custom_text_form_field/custom_text_form_field_widget.dart';
+import 'package:raro_budget/src/shared/widgets/custom_visible/custom_visible_widget.dart';
+
+class PasswordWidget extends StatefulWidget {
+  PasswordWidget({Key? key}) : super(key: key);
+
+  @override
+  _PasswordWidgetState createState() => _PasswordWidgetState();
+}
+
+class _PasswordWidgetState extends State<PasswordWidget> {
+  TextEditingController _passwordController = TextEditingController();
+  TextEditingController _confirmPasswordController = TextEditingController();
+
+  final _validator = Validators();
+
+  bool passwordVisible = true;
+  bool confirmPasswordVisible = true;
+
+  @override
+  void dispose() {
+    _passwordController.dispose();
+
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(40.0, 74.0, 48.0, 32.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Image(
+              width: 100.0,
+              height: 54.0,
+              image: AssetImage('assets/images/logo_budget_blue.png'),
+            ),
+            CustomMainTextTitle(
+              titleFirstLine: "Bem-vindo!",
+              subtitle: "Agora crie sua senha contendo:",
+              newUser: false,
+            ),
+            Padding(
+              padding: const EdgeInsets.only(top: 40.0),
+              child: Form(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      "•  pelo menos oito caracteres\n•  letras maiúsculas, letras \n   minúsculas, números e símbolos",
+                      style: TextStyles.black5416w400Roboto,
+                    ),
+                    SizedBox(
+                      height: 30,
+                    ),
+                    CustomTextFormField(
+                      name: 'Crie uma senha',
+                      obscureText: passwordVisible,
+                      validator: (value) => _validator.passwordValidator(value),
+                      controller: _passwordController,
+                      icon: VisibleWidget(
+                        visible: passwordVisible,
+                        onPressed: () {
+                          setState(() {
+                            passwordVisible = !passwordVisible;
+                          });
+                        },
+                      ),
+                    ),
+                    SizedBox(
+                      height: 20,
+                    ),
+                    CustomTextFormField(
+                      name: 'Confirme sua senha',
+                      obscureText: confirmPasswordVisible,
+                      controller: _confirmPasswordController,
+                      icon: VisibleWidget(
+                        visible: confirmPasswordVisible,
+                        onPressed: () {
+                          setState(() {
+                            confirmPasswordVisible = !confirmPasswordVisible;
+                          });
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/modules/login/create_account/widgets/phone_cpf_widget.dart
+++ b/lib/src/modules/login/create_account/widgets/phone_cpf_widget.dart
@@ -14,7 +14,6 @@ class PhoneCPFWidget extends StatefulWidget {
 class _PhoneCPFWidgetState extends State<PhoneCPFWidget> {
   TextEditingController _phoneController = TextEditingController();
   TextEditingController _cpfController = TextEditingController();
-  GlobalKey<FormState> _formKey = GlobalKey<FormState>();
 
   final validators = Validators();
 
@@ -29,7 +28,7 @@ class _PhoneCPFWidgetState extends State<PhoneCPFWidget> {
           padding: const EdgeInsets.only(
               left: 48.0, top: 74.0, right: 48.0, bottom: 32.0),
           child: Form(
-            key: _formKey,
+            // key
             child: SingleChildScrollView(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/src/shared/validators/validators.dart
+++ b/lib/src/shared/validators/validators.dart
@@ -19,4 +19,40 @@ class Validators {
       return null;
     }
   }
+
+  // não testei, se não teria que arrumar toda a parte de estado do fluxo de cadastro,
+  // achei melhor esperar
+  String? passwordValidator(String? value) {
+    RegExp checkCharacteres = RegExp(
+        r"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$");
+
+    RegExp hasUpperLowerCaseLetters =
+        RegExp(r"^(?=.*[a-z])(?=.*[A-Z])[a-zA-Z]{8,}$");
+
+    RegExp hasNumbers = RegExp(r"^(?=.*\d)[\d]{8,}$");
+
+    RegExp hasSymbols = RegExp(r"^(?=.*?[#?!@$%^&*-]){8,}$");
+
+    if (value == null || value.isEmpty) {
+      return "Ops! Coloque uma senha!";
+    }
+
+    if (value.length < 8) {
+      return "Precisa ter pelo menos 8 caracteres!";
+    }
+
+    if (!checkCharacteres.hasMatch(value)) {
+      if (!hasUpperLowerCaseLetters.hasMatch(value)) {
+        return "Precisa ter letras maiúsculas e minúsculas";
+      } else if (!hasNumbers.hasMatch(value)) {
+        return "Precisa ter pelo menos um número";
+      } else if (!hasSymbols.hasMatch(value)) {
+        return "Precisa ter pelo menos um símbolo";
+      } else {
+        return null;
+      }
+    } else {
+      return null;
+    }
+  }
 }

--- a/lib/src/shared/widgets/custom_visible/custom_visible_widget.dart
+++ b/lib/src/shared/widgets/custom_visible/custom_visible_widget.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class VisibleWidget extends StatelessWidget {
+  final bool visible;
+  final void Function() onPressed;
+
+  const VisibleWidget({
+    Key? key,
+    required this.visible,
+    required this.onPressed,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: Icon(
+        visible ? Icons.lock_outlined : Icons.lock_open_outlined,
+      ),
+      onPressed: onPressed,
+    );
+  }
+}


### PR DESCRIPTION
Apaguei a pasta "authentication", a função de verificar autenticação (usário logado ou não) vai ficar na Splash.

Adicionado:
- password widget (fluxo de cadastro);
- proposta de validação - **não testei, precisa testar ainda!**
- custom widget visible: não estava no Figma, mas o campo de password em 100% dos casos (pelo menos dos que eu conheço, são obscure text com opção de tornar visivel quando o usuário assim desejar); obs.: a cor deixei padrão pois casa bem com as cores do app;

Faltando:
- validação do confirm password: a ser implementado (checagem simples se os 2 valores batem);

_PS.: não fui adiante nos testes de validação pois seria necessário fazer o fluxo todo de cadastro, gerencia de estado etc; isso seria de outra issue/log._